### PR TITLE
add ability for infinite scroll

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -156,12 +156,24 @@ var Select2Component = Ember.Component.extend({
 
         self.sendAction('query', query, deferred);
 
-        deferred.promise.then(function(data) {
-          if (data instanceof Ember.ArrayProxy) {
-            data = data.toArray();
+        deferred.promise.then(function(result) {
+          var data = result;
+          var more = false;
+
+          if (result instanceof Ember.ArrayProxy) {
+            data = result.toArray();
+          } else if (!Array.isArray(result)) {
+            if (result.data instanceof Ember.ArrayProxy) {
+              data = result.data.toArray();
+            } else {
+              data = result.data;
+            }
+            more = result.more;
           }
+
           query.callback({
-            results: data
+            results: data,
+            more: more
           });
         }, function(reason) {
           query.callback({

--- a/tests/dummy/app/controllers/examples.js
+++ b/tests/dummy/app/controllers/examples.js
@@ -102,7 +102,7 @@ var ExamplesController = Ember.Controller.extend({
       this.toggleProperty('enabled');
     },
 
-    queryPizzas: function(query, deferred) {
+    queryPizzas: function(query, deferred, isInfiniteScroll) {
       setTimeout(function() {
         var data = [];
         switch(query.term) {
@@ -119,10 +119,18 @@ var ExamplesController = Ember.Controller.extend({
                 text: 'Pizza ' + query.term + ' ' + i
               });
             }
-            deferred.resolve(data);
+            if (isInfiniteScroll) {
+              deferred.resolve({data: data, more: true});
+            } else {
+              deferred.resolve(data);
+            }
             break;
         }
       }, 300);
+    },
+
+    queryInfiniteScrollPizzas: function(query, deferred) {
+      this.send('queryPizzas', query, deferred, true);
     }
   }
 });

--- a/tests/dummy/app/templates/examples.hbs
+++ b/tests/dummy/app/templates/examples.hbs
@@ -258,6 +258,56 @@
   </div>
 </div>
 
+<h3>Infinite Scroll with Typeahead & Ajax Queries</h3>
+<p>Imagine you sell so many pizzas that you don't want to send all of them to the client, and using Typeahead doesn't give you a large enough filter. You can implement infinite scroll using the <code>more</code> property</p>
+<div class="row">
+  <div class="col-sm-6">
+    <h4>The Component</h4>
+    <div class="example-box">
+      <p>The component is exactly the same as the regular Typeahead and Ajax query from above</p>
+      {{select-2
+          placeholder="Choose from our many pizzas"
+          value=chosenTypeaheadPizza
+          typeaheadSearchingText="Searching pizzas"
+          typeaheadNoMatchesText="No pizzas found for '%@'"
+          typeaheadErrorText="Loading failed: %@"
+          minimumInputLength=3
+          maximumInputLength=10
+          query="queryInfiniteScrollPizzas"
+      }}
+    </div>
+    {{#highlight-code lang=".hbs"}}\{{select-2
+    placeholder="Choose from our many pizzas"
+    value=chosenTypeaheadPizza
+    typeaheadSearchingText="Searching pizzas"
+    typeaheadNoMatchesText="No pizzas found for '%@'"
+    typeaheadErrorText="Loading failed: %@"
+    minimumInputLength=3
+    maximumInputLength=10
+    query="queryPizzas"
+}}{{/highlight-code}}
+  </div>
+  <div class="col-sm-6">
+    <h4>The Controller</h4>
+    <div class="example-box">
+      <p>There are a few minor changes from the regular Typeahead and Ajax query from above.
+      <p>Instead of sending in deferred.resolve as the callback, you need to implement your own callback and call deferred.resolve with the data that was returned and more property</p>
+      <p>Implement <code>more: true</code> when there is still more data to load, and <code>more: false</code> when the server has responded with all the data and there is nothing to load.</p>
+    </div>
+    {{#highlight-code lang=".js"}}Ember.Controller.extend({
+  actions: {
+    queryPizzas: function(query, deferred) {
+      this.store.find('myModel', { name: query.term })
+        .then(function(data) {
+          //'when everything has been loaded, specify more: false'
+          deferred.resolve({data: data, more: true});
+        }, deferred.reject);
+    }
+  }
+});{{/highlight-code}}
+  </div>
+</div>
+
 <h3>Miscellaneous</h3>
 <div class="row">
   <div class="col-sm-6">


### PR DESCRIPTION
add ability for infinite scroll.
Allows an object with `more` property to be passed in.

http://select2.github.io/select2/#infinite

this matches my merge into the original ember-select-2 (the one we forked from) https://github.com/iStefo/ember-select-2/pull/85. That pull request was merged this weekend, so this one should be good to go.
